### PR TITLE
Introduce AbstractMqttPacketDispatcher to centralize packet dispatch & hook handling

### DIFF
--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/AbstractMqttPacketDispatcher.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/AbstractMqttPacketDispatcher.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.mqtt.cs.protocol;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.util.ReferenceCountUtil;
+import org.apache.rocketmq.mqtt.common.hook.HookResult;
+import org.apache.rocketmq.mqtt.common.hook.UpstreamHookManager;
+import org.apache.rocketmq.mqtt.common.model.MqttMessageUpContext;
+import org.apache.rocketmq.mqtt.cs.channel.ChannelDecodeException;
+import org.apache.rocketmq.mqtt.cs.channel.ChannelException;
+import org.apache.rocketmq.mqtt.cs.channel.ChannelInfo;
+import org.slf4j.Logger;
+
+import java.util.concurrent.CompletableFuture;
+
+public abstract class AbstractMqttPacketDispatcher extends SimpleChannelInboundHandler<MqttMessage> {
+
+    protected abstract Logger logger();
+
+    protected abstract UpstreamHookManager upstreamHookManager();
+
+    protected abstract boolean preHandler(ChannelHandlerContext ctx, MqttMessage msg);
+
+    protected abstract void doChannelRead(ChannelHandlerContext ctx, MqttMessage msg, HookResult upstreamHookResult);
+
+    protected abstract MqttMessageUpContext buildMqttMessageUpContext(ChannelHandlerContext ctx);
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, MqttMessage msg) {
+        if (!ctx.channel().isActive()) {
+            return;
+        }
+        if (!msg.decoderResult().isSuccess()) {
+            throw new ChannelDecodeException(ChannelInfo.getClientId(ctx.channel()) + "," + msg.decoderResult());
+        }
+        ChannelInfo.touch(ctx.channel());
+        boolean preResult = preHandler(ctx, msg);
+        if (!preResult) {
+            return;
+        }
+
+        CompletableFuture<HookResult> upstreamHookResult;
+        try {
+            if (msg instanceof MqttPublishMessage) {
+                ((MqttPublishMessage) msg).retain();
+            }
+            upstreamHookResult = upstreamHookManager().doUpstreamHook(buildMqttMessageUpContext(ctx), msg);
+            if (upstreamHookResult == null) {
+                doChannelRead(ctx, msg, null);
+                return;
+            }
+        } catch (Throwable t) {
+            logger().error("", t);
+            if (msg instanceof MqttPublishMessage) {
+                ReferenceCountUtil.release(msg);
+            }
+            throw new ChannelException(t.getMessage());
+        }
+
+        upstreamHookResult.whenComplete((hookResult, throwable) -> {
+            if (msg instanceof MqttPublishMessage) {
+                ReferenceCountUtil.release(msg);
+            }
+            if (throwable != null) {
+                logger().error("", throwable);
+                ctx.fireExceptionCaught(new ChannelException(throwable.getMessage()));
+                return;
+            }
+            if (hookResult == null) {
+                ctx.fireExceptionCaught(new ChannelException("UpstreamHook Result Unknown"));
+                return;
+            }
+            try {
+                doChannelRead(ctx, msg, hookResult);
+            } catch (Throwable t) {
+                logger().error("", t);
+                ctx.fireExceptionCaught(new ChannelException(t.getMessage()));
+            }
+        });
+    }
+}

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt/MqttPacketDispatcher.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt/MqttPacketDispatcher.java
@@ -20,21 +20,18 @@ package org.apache.rocketmq.mqtt.cs.protocol.mqtt;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttPubAckMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
-import io.netty.util.ReferenceCountUtil;
 import org.apache.rocketmq.mqtt.common.hook.HookResult;
 import org.apache.rocketmq.mqtt.common.hook.UpstreamHookManager;
 import org.apache.rocketmq.mqtt.common.model.MqttMessageUpContext;
 import org.apache.rocketmq.mqtt.common.util.HostInfo;
-import org.apache.rocketmq.mqtt.cs.channel.ChannelDecodeException;
-import org.apache.rocketmq.mqtt.cs.channel.ChannelException;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelInfo;
+import org.apache.rocketmq.mqtt.cs.protocol.AbstractMqttPacketDispatcher;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttConnectHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttDisconnectHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttPingHandler;
@@ -50,12 +47,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Resource;
-import java.util.concurrent.CompletableFuture;
 
 
 @ChannelHandler.Sharable
 @Component
-public class MqttPacketDispatcher extends SimpleChannelInboundHandler<MqttMessage> {
+public class MqttPacketDispatcher extends AbstractMqttPacketDispatcher {
     private static Logger logger = LoggerFactory.getLogger(MqttPacketDispatcher.class);
 
     @Resource
@@ -92,58 +88,17 @@ public class MqttPacketDispatcher extends SimpleChannelInboundHandler<MqttMessag
     private UpstreamHookManager upstreamHookManager;
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, MqttMessage msg) throws Exception {
-        if (!ctx.channel().isActive()) {
-            return;
-        }
-        if (!msg.decoderResult().isSuccess()) {
-            throw new ChannelDecodeException(ChannelInfo.getClientId(ctx.channel()) + "," + msg.decoderResult());
-        }
-        ChannelInfo.touch(ctx.channel());
-        boolean preResult = preHandler(ctx, msg);
-        if (!preResult) {
-            return;
-        }
-        CompletableFuture<HookResult> upstreamHookResult;
-        try {
-            if (msg instanceof MqttPublishMessage) {
-                ((MqttPublishMessage) msg).retain();
-            }
-            upstreamHookResult = upstreamHookManager.doUpstreamHook(buildMqttMessageUpContext(ctx), msg);
-            if (upstreamHookResult == null) {
-                _channelRead0(ctx, msg, null);
-                return;
-            }
-        } catch (Throwable t) {
-            logger.error("", t);
-            if (msg instanceof MqttPublishMessage) {
-                ReferenceCountUtil.release(msg);
-            }
-            throw new ChannelException(t.getMessage());
-        }
-        upstreamHookResult.whenComplete((hookResult, throwable) -> {
-            if (msg instanceof MqttPublishMessage) {
-                ReferenceCountUtil.release(msg);
-            }
-            if (throwable != null) {
-                logger.error("", throwable);
-                ctx.fireExceptionCaught(new ChannelException(throwable.getMessage()));
-                return;
-            }
-            if (hookResult == null) {
-                ctx.fireExceptionCaught(new ChannelException("UpstreamHook Result Unknown"));
-                return;
-            }
-            try {
-                _channelRead0(ctx, msg, hookResult);
-            } catch (Throwable t) {
-                logger.error("", t);
-                ctx.fireExceptionCaught(new ChannelException(t.getMessage()));
-            }
-        });
+    protected Logger logger() {
+        return logger;
     }
 
-    private void _channelRead0(ChannelHandlerContext ctx, MqttMessage msg, HookResult upstreamHookResult) {
+    @Override
+    protected UpstreamHookManager upstreamHookManager() {
+        return upstreamHookManager;
+    }
+
+    @Override
+    protected void doChannelRead(ChannelHandlerContext ctx, MqttMessage msg, HookResult upstreamHookResult) {
         switch (msg.fixedHeader().messageType()) {
             case CONNECT:
                 mqttConnectHandler.doHandler(ctx, (MqttConnectMessage) msg, upstreamHookResult);
@@ -179,7 +134,8 @@ public class MqttPacketDispatcher extends SimpleChannelInboundHandler<MqttMessag
         }
     }
 
-    private boolean preHandler(ChannelHandlerContext ctx, MqttMessage msg) {
+    @Override
+    protected boolean preHandler(ChannelHandlerContext ctx, MqttMessage msg) {
         switch (msg.fixedHeader().messageType()) {
             case CONNECT:
                 return mqttConnectHandler.preHandler(ctx, (MqttConnectMessage) msg);
@@ -206,7 +162,8 @@ public class MqttPacketDispatcher extends SimpleChannelInboundHandler<MqttMessag
         }
     }
 
-    public MqttMessageUpContext buildMqttMessageUpContext(ChannelHandlerContext ctx) {
+    @Override
+    protected MqttMessageUpContext buildMqttMessageUpContext(ChannelHandlerContext ctx) {
         MqttMessageUpContext context = new MqttMessageUpContext();
         Channel channel = ctx.channel();
         context.setClientId(ChannelInfo.getClientId(channel));

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt5/Mqtt5PacketDispatcher.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt5/Mqtt5PacketDispatcher.java
@@ -20,20 +20,17 @@ package org.apache.rocketmq.mqtt.cs.protocol.mqtt5;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
-import io.netty.util.ReferenceCountUtil;
 import org.apache.rocketmq.mqtt.common.hook.HookResult;
 import org.apache.rocketmq.mqtt.common.hook.UpstreamHookManager;
 import org.apache.rocketmq.mqtt.common.model.MqttMessageUpContext;
 import org.apache.rocketmq.mqtt.common.util.HostInfo;
-import org.apache.rocketmq.mqtt.cs.channel.ChannelDecodeException;
-import org.apache.rocketmq.mqtt.cs.channel.ChannelException;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelInfo;
+import org.apache.rocketmq.mqtt.cs.protocol.AbstractMqttPacketDispatcher;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt5.handler.Mqtt5AuthHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt5.handler.Mqtt5ConnectHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt5.handler.Mqtt5DisconnectHandler;
@@ -50,12 +47,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Resource;
-import java.util.concurrent.CompletableFuture;
 
 
 @ChannelHandler.Sharable
 @Component
-public class Mqtt5PacketDispatcher extends SimpleChannelInboundHandler<MqttMessage> {
+public class Mqtt5PacketDispatcher extends AbstractMqttPacketDispatcher {
     private static Logger logger = LoggerFactory.getLogger(Mqtt5PacketDispatcher.class);
 
     @Resource
@@ -95,58 +91,17 @@ public class Mqtt5PacketDispatcher extends SimpleChannelInboundHandler<MqttMessa
     private UpstreamHookManager upstreamHookManager;
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, MqttMessage msg) {
-        if (!ctx.channel().isActive()) {
-            return;
-        }
-        if (!msg.decoderResult().isSuccess()) {
-            throw new ChannelDecodeException(ChannelInfo.getClientId(ctx.channel()) + "," + msg.decoderResult());
-        }
-        ChannelInfo.touch(ctx.channel());
-        boolean preResult = preHandler(ctx, msg);
-        if (!preResult) {
-            return;
-        }
-        CompletableFuture<HookResult> upstreamHookResult;
-        try {
-            if (msg instanceof MqttPublishMessage) {
-                ((MqttPublishMessage) msg).retain();
-            }
-            upstreamHookResult = upstreamHookManager.doUpstreamHook(buildMqttMessageUpContext(ctx), msg);
-            if (upstreamHookResult == null) {
-                _channelRead0(ctx, msg, null);
-                return;
-            }
-        } catch (Throwable t) {
-            logger.error("", t);
-            if (msg instanceof MqttPublishMessage) {
-                ReferenceCountUtil.release(msg);
-            }
-            throw new ChannelException(t.getMessage());
-        }
-        upstreamHookResult.whenComplete((hookResult, throwable) -> {
-            if (msg instanceof MqttPublishMessage) {
-                ReferenceCountUtil.release(msg);
-            }
-            if (throwable != null) {
-                logger.error("", throwable);
-                ctx.fireExceptionCaught(new ChannelException(throwable.getMessage()));
-                return;
-            }
-            if (hookResult == null) {
-                ctx.fireExceptionCaught(new ChannelException("UpstreamHook Result Unknown"));
-                return;
-            }
-            try {
-                _channelRead0(ctx, msg, hookResult);
-            } catch (Throwable t) {
-                logger.error("", t);
-                ctx.fireExceptionCaught(new ChannelException(t.getMessage()));
-            }
-        });
+    protected Logger logger() {
+        return logger;
     }
 
-    private void _channelRead0(ChannelHandlerContext ctx, MqttMessage msg, HookResult upstreamHookResult) {
+    @Override
+    protected UpstreamHookManager upstreamHookManager() {
+        return upstreamHookManager;
+    }
+
+    @Override
+    protected void doChannelRead(ChannelHandlerContext ctx, MqttMessage msg, HookResult upstreamHookResult) {
         switch (msg.fixedHeader().messageType()) {
             case CONNECT:
                 mqtt5ConnectHandler.doHandler(ctx, (MqttConnectMessage) msg, upstreamHookResult);
@@ -185,7 +140,8 @@ public class Mqtt5PacketDispatcher extends SimpleChannelInboundHandler<MqttMessa
         }
     }
 
-    private boolean preHandler(ChannelHandlerContext ctx, MqttMessage msg) {
+    @Override
+    protected boolean preHandler(ChannelHandlerContext ctx, MqttMessage msg) {
         switch (msg.fixedHeader().messageType()) {
             case CONNECT:
                 return mqtt5ConnectHandler.preHandler(ctx, (MqttConnectMessage) msg);
@@ -212,7 +168,8 @@ public class Mqtt5PacketDispatcher extends SimpleChannelInboundHandler<MqttMessa
         }
     }
 
-    public MqttMessageUpContext buildMqttMessageUpContext(ChannelHandlerContext ctx) {
+    @Override
+    protected MqttMessageUpContext buildMqttMessageUpContext(ChannelHandlerContext ctx) {
         MqttMessageUpContext context = new MqttMessageUpContext();
         Channel channel = ctx.channel();
         context.setClientId(ChannelInfo.getClientId(channel));


### PR DESCRIPTION
### Motivation
- Consolidate duplicated `channelRead0` logic across MQTT v3 and v5 dispatchers to centralize upstream hook invocation, retain/release handling, channel decoding checks, and exception handling.

### Description
- Add `AbstractMqttPacketDispatcher` which implements the common `channelRead0` flow, upstream hook invocation, message `retain`/`release`, and declares abstract methods `logger()`, `upstreamHookManager()`, `preHandler(...)`, `doChannelRead(...)`, and `buildMqttMessageUpContext(...)`.
- Refactor `MqttPacketDispatcher` and `Mqtt5PacketDispatcher` to extend `AbstractMqttPacketDispatcher` and remove duplicated `channelRead0` implementation by providing concrete implementations of the abstract methods.
- Update both dispatchers to delegate per-message-type handling to their existing handler components via `doChannelRead` and to provide context construction in `buildMqttMessageUpContext`.

### Testing
- Ran the module test suite with `mvn -pl mqtt-cs -DskipTests=false test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a910d4448320b526813404e2a39d)